### PR TITLE
[Waiting vagrant 1.8.2] Use ansible_local provisionner

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Vagrant implementation of [LinkValue/majora-ansible-playbook](https://github.com
 
 This Vagrant boilerplate also shows how to add other roles in `ansible/galaxy-additionals.yml` in order to fulfill majora-ansible-playbook dependencies (such as `ruby`).
 
-
+ * You need to patch vagrant before using this, (with vagrant < 1.8.2) : https://github.com/mitchellh/vagrant/commit/9dbdb9397a92d4fc489e9afcb022621df7f60d11
+ * Vagrant destroy command works only if vagrant is not  running. Use vagrant suspend before destroying.
 
 ## Requirements
 
@@ -24,7 +25,12 @@ This Vagrant boilerplate also shows how to add other roles in `ansible/galaxy-ad
 * Ansible: http://docs.ansible.com/ansible/intro_installation.html#latest-releases-via-apt-ubuntu
 * NFS: `sudo apt-get install nfs-common nfs-kernel-server`
 
-
+### Windows
+* VirtualBox: https://www.virtualbox.org/wiki/Downloads
+* VirtualBox Extension Pack: https://www.virtualbox.org/wiki/Downloads
+* Vagrant: http://www.vagrantup.com/downloads
+* NFS : install vagrant plugin : https://github.com/winnfsd/vagrant-winnfsd
+* Change the ssh folder in vars.local.yml
 
 ## Usage
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,6 +3,12 @@
 
 require 'yaml'
 
+# Get ssh conf
+current_dir = File.dirname(File.expand_path(__FILE__))
+configs = YAML.load_file("#{current_dir}/ansible/vars.local.yml")
+ssh_host_folder = configs['ssh_host_folder']
+ssh_folder = configs['ssh_folder']
+
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
@@ -28,10 +34,24 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         # Share folders
         local.vm.synced_folder ".", "/var/www/AcmeProject/", id:"project-root", type: "nfs", mount_options: ["nolock,vers=3,udp,noatime,actimeo=1"]
 
+        # Share ssh
+        local.vm.provision "file", source: ssh_host_folder, destination: ssh_folder
+
+        # Get git
+        local.vm.provision "shell", inline: "apt-get install git -y"
+
         # Ansible provisionning
-        local.vm.provision :ansible do |ansible|
+        local.vm.provision "ansible_local" do |ansible|
             ansible.playbook = "ansible/app.yml"
+            ansible.install = true
+            ansible.version = "latest"
+            ansible.verbose = true
             ansible.limit = "all"
+            ansible.provisioning_path = "/var/www/AcmeProject/"
+            ansible.galaxy_command = "ansible-galaxy install --force -p /var/www/AcmeProject/ansible --role-file=/var/www/AcmeProject/ansible/galaxy-majora.yml && ansible-galaxy install --force -p /var/www/AcmeProject/ansible/roles --role-file=/var/www/AcmeProject/ansible/galaxy-additionals.yml"
+            # This is required to launch ansible-galaxy command
+            # Perhaps not anymore on vagrant 1.8.2
+            ansible.galaxy_role_file = "a"
         end
 
     end

--- a/ansible/vars.local.yml.dist
+++ b/ansible/vars.local.yml.dist
@@ -4,3 +4,11 @@ zsh_theme: 'steeef'
 zsh_editor: 'vim'
 
 composer_github_token: ''
+
+# Ssh folder on host
+# windows : /Users/MyUser/.ssh
+# Used only in the vagrant file to copy ssh folder on guest and run ansible_local
+ssh_host_folder: ~/.ssh
+# Folder on vm to store the ssh key
+# Needed by the ssh-forward role
+ssh_folder: /tmp/ssh-forward


### PR DESCRIPTION
- You need to patch vagrant before using this, (with vagrant < 1.8.2) : https://github.com/mitchellh/vagrant/commit/9dbdb9397a92d4fc489e9afcb022621df7f60d11
- Vagrant destroy command works only if vagrant is not  running. Use vagrant suspend before destroying.
- To make ssh-forward works, we need to copy ssh folder in temp folder on guest, because ansible is executed on the guest and not the host
- The new ssh settings is made in ansible/vars.local.yml, even though it's used by the vagrant file, but i think it's easier to have all settings in one place
