### PR TITLE
split vagrant-parameters.yml file + document sharing strategies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 /.vagrant/
 /ansible/roles/
 /ansible/vars.local.yml
-/ansible/vagrant-parameters.yml
+/ansible/vagrant-parameters.local.yml
 /ansible/*.retry
 
 # if you set sharing_strategy = 'subdirectory', you'll probably want to gitignore the shared subdirectory:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -65,20 +65,41 @@ Dir.glob('ansible/*.dist') do |dist_file|
     end
 end
 
-# Merge "ansible/vagrant-parameters.yml" with default parameters values
+# Merge "ansible/vagrant-parameters.local.yml" with "ansible/vagrant-parameters.yml" with default parameters values
+file_local_parameters = YAML.load_file('ansible/vagrant-parameters.local.yml') || {}
 file_parameters = YAML.load_file('ansible/vagrant-parameters.yml') || {}
 parameters = {
-    'vm_memory' => file_parameters['vm_memory'].instance_of?(Integer) ? file_parameters['vm_memory'] : 2048,
-    'vm_cpus' => file_parameters['vm_cpus'].instance_of?(Integer) ? file_parameters['vm_cpus'] : 2,
-    'vm_ip' => file_parameters['vm_ip'].instance_of?(String) ? file_parameters['vm_ip'] : '192.168.100.10',
-    'vm_ip_aliases' => file_parameters['vm_ip_aliases'].instance_of?(Array) ? file_parameters['vm_ip_aliases'] : [],
-    'vm_hostname' => file_parameters['vm_hostname'].instance_of?(String) ? file_parameters['vm_hostname'] : 'majora-ansible-vagrant',
-    'sharing_strategy' => ['self', 'subdirectory'].include?(file_parameters['sharing_strategy']) ? file_parameters['sharing_strategy'] : 'self',
-    'sharing_self_absolute_path_in_vm' => file_parameters['sharing_self_absolute_path_in_vm'].instance_of?(String) ? file_parameters['sharing_self_absolute_path_in_vm'] : '/var/www/majora-ansible-vagrant',
-    'sharing_subdirectory_relative_path' => file_parameters['sharing_subdirectory_relative_path'].instance_of?(String) ? file_parameters['sharing_subdirectory_relative_path'] : 'www',
-    'sharing_subdirectory_absolute_path_in_vm' => file_parameters['sharing_subdirectory_absolute_path_in_vm'].instance_of?(String) ? file_parameters['sharing_subdirectory_absolute_path_in_vm'] : '/var/www',
-    'forwarded_files' => get_forwarded_files_from_parameters(file_parameters['forwarded_files_from_home']),
-    'install_ansible_roles' => [true, false].include?(file_parameters['install_ansible_roles']) ? file_parameters['install_ansible_roles'] : true,
+    'vm_memory' => file_local_parameters['vm_memory'].instance_of?(Integer) ? file_local_parameters['vm_memory']
+        : file_parameters['vm_memory'].instance_of?(Integer) ? file_parameters['vm_memory']
+        : 2048,
+    'vm_cpus' => file_local_parameters['vm_cpus'].instance_of?(Integer) ? file_local_parameters['vm_cpus']
+        : file_parameters['vm_cpus'].instance_of?(Integer) ? file_parameters['vm_cpus']
+        : 2,
+    'vm_ip' => file_local_parameters['vm_ip'].instance_of?(String) ? file_local_parameters['vm_ip']
+        : file_parameters['vm_ip'].instance_of?(String) ? file_parameters['vm_ip']
+        : '192.168.100.1',
+    'vm_ip_aliases' => file_local_parameters['vm_ip_aliases'].instance_of?(Array) ? file_local_parameters['vm_ip_aliases']
+        : file_parameters['vm_ip_aliases'].instance_of?(Array) ? file_parameters['vm_ip_aliases']
+        : [],
+    'vm_hostname' => file_local_parameters['vm_hostname'].instance_of?(String) ? file_local_parameters['vm_hostname']
+        : file_parameters['vm_hostname'].instance_of?(String) ? file_parameters['vm_hostname']
+        : 'majora-ansible-vagrant',
+    'sharing_strategy' => ['self', 'subdirectory'].include?(file_local_parameters['sharing_strategy']) ? file_local_parameters['sharing_strategy']
+        : ['self', 'subdirectory'].include?(file_parameters['sharing_strategy']) ? file_parameters['sharing_strategy']
+        : 'self',
+    'sharing_self_absolute_path_in_vm' => file_local_parameters['sharing_self_absolute_path_in_vm'].instance_of?(String) ? file_local_parameters['sharing_self_absolute_path_in_vm']
+        : file_parameters['sharing_self_absolute_path_in_vm'].instance_of?(String) ? file_parameters['sharing_self_absolute_path_in_vm']
+        : '/var/www/majora-ansible-vagrant',
+    'sharing_subdirectory_relative_path' => file_local_parameters['sharing_subdirectory_relative_path'].instance_of?(String) ? file_local_parameters['sharing_subdirectory_relative_path']
+        : file_parameters['sharing_subdirectory_relative_path'].instance_of?(String) ? file_parameters['sharing_subdirectory_relative_path']
+        : 'www',
+    'sharing_subdirectory_absolute_path_in_vm' => file_local_parameters['sharing_subdirectory_absolute_path_in_vm'].instance_of?(String) ? file_local_parameters['sharing_subdirectory_absolute_path_in_vm']
+        : file_parameters['sharing_subdirectory_absolute_path_in_vm'].instance_of?(String) ? file_parameters['sharing_subdirectory_absolute_path_in_vm']
+        : '/var/www',
+    'install_ansible_roles' => [true, false].include?(file_local_parameters['install_ansible_roles']) ? file_local_parameters['install_ansible_roles']
+        : [true, false].include?(file_parameters['install_ansible_roles']) ? file_parameters['install_ansible_roles']
+        : true,
+    'forwarded_files' => get_forwarded_files_from_parameters(file_local_parameters['forwarded_files_from_home'].instance_of?(Array) ? file_local_parameters['forwarded_files_from_home'] : file_parameters['forwarded_files_from_home']),
 }
 
 # VMs configuration

--- a/ansible/vagrant-parameters.local.yml.dist
+++ b/ansible/vagrant-parameters.local.yml.dist
@@ -1,0 +1,15 @@
+---
+
+# VM RAM usage (in MB)
+vm_memory: 2048
+
+# VM CPUs usage
+vm_cpus: 2
+
+# VM IP address
+vm_ip: '192.168.100.1'
+
+# Relative paths from your user home directory to a file (or a directory) which you want to be available in the user home directory of the VM
+# Note: the forwarded files are not synchronized => files are only copied from host to guest at provisioning
+# Note2: the forwarded files permissions are set to "700" which is low enough for "private keys" forwarding
+forwarded_files_from_home: ['.ssh/id_rsa']

--- a/ansible/vagrant-parameters.yml
+++ b/ansible/vagrant-parameters.yml
@@ -1,21 +1,12 @@
 ---
 
-# VM RAM usage (in MB)
-vm_memory: 2048
-
-# VM CPUs usage
-vm_cpus: 2
-
-# VM IP address
-vm_ip: '192.168.100.10'
+# VM hostname (this will be added to the "vm_ip_aliases" list, displayed in your SSH terminal, etc.)
+vm_hostname: 'majora-ansible-vagrant'
 
 # List of aliases bound to the Virtual Machine's IP (see "vm_ip")
 # If the plugin "vagrant-hostmanager" is installed, these aliases will be added to your "/etc/hosts" file automatically.
 # Else, aliases will be displayed in the console during VM provisioning, then it will be up to you to copy/paste this output in your "/etc/hosts" file.
 vm_ip_aliases: []
-
-# VM hostname (this will be added to the "vm_ip_aliases" list, displayed in your SSH terminal, etc.)
-vm_hostname: 'majora-ansible-vagrant'
 
 # Shared folders strategy, possible values are 'self' or 'subdirectory'.
 # 'self'         => share this project root with the VM (i.e. "Vagrantfile" is shared),
@@ -32,11 +23,6 @@ sharing_subdirectory_relative_path: 'www'
 
 # Absolute path of the shared subdirectory on the VM side (used if shared folders strategy is 'subdirectory')
 sharing_subdirectory_absolute_path_in_vm: '/var/www'
-
-# Relative paths from your user home directory to a file (or a directory) which you want to be available in the user home directory of the VM
-# Note: the forwarded files are not synchronized => files are only copied from host to guest at provisioning
-# Note2: the forwarded files permissions are set to "700" which is low enough for "private keys" forwarding
-forwarded_files_from_home: ['.ssh/id_rsa']
 
 # If you set this to false, the "roles" directory won't be (re)downloaded during VM provisioning
 install_ansible_roles: true


### PR DESCRIPTION
## Why
Because it wasn't clear enough which Vagrant parameters should be overrided on a per user basis...
And the "sharing strategy" wasn't clear enough too

## How
- Split the `vagrant-parameters.yml.dist` file into `vagrant-parameters.yml` (global vagrant parameters for everyone) and `vagrant-parameters.local.yml.dist` (local vagrant parameters which override the global ones)
- More documentation!!!
